### PR TITLE
Matplotlib update and b normalization bug

### DIFF
--- a/ExB.py
+++ b/ExB.py
@@ -56,7 +56,7 @@ for n in range(N):
 
 ## 3D trajectory
 fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = fig.add_subplot(projection='3d')
 for n in range(N):
     ax.plot(x[n,:]*1e6, y[n,:]*1e6, z[n,:], label='part ' + str(n))
 ax.set_xlabel('$x$ [µm]')

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ mass = cst.Mp
 E0 = np.array((0, 0, 0))
 B0 = np.array((0, 0, 1))
 w0 = np.abs(charge) * np.sqrt(np.sum(B0*B0, axis=0)) / mass
-dt = 0.001 / w0       # timestep
+dt = 0.01 / w0       # timestep
 Np = 10             # Number of cyclotronic periods
 
 Tf = Np * 2 * np.pi / w0
@@ -36,8 +36,9 @@ vx, vy, vz = np.zeros((Nt)), np.zeros((Nt)), np.zeros((Nt))   # velocities
 part = Particle(mass, charge)
 part.initPos(0, 0, 0)
 part.initSpeed(200, 0, 0)
+vx[0] = 200
 
-for i in range(Nt):
+for i in range(1, Nt):
     part.push(dt, E0, B0)
     x[i], y[i], z[i] = part.r
     vx[i], vy[i], vz[i] = part.v

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ plt.show()
 
 ## 3D trajectory
 fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = fig.add_subplot(projection='3d')
 ax.plot(x*1e6, y*1e6, z)
 ax.set_xlabel('$x$ [µm]')
 ax.set_ylabel('$y$ [µm]')

--- a/particle.py
+++ b/particle.py
@@ -40,7 +40,7 @@ class Particle:
         ## Rotation of speed according to B
         t = self.charge * dt * B / (2 * self.mass)
         v1 = self.v + np.cross(self.v, t)
-        self.v += np.cross(v1, 2 /(1 + np.abs(t)**2) * t)
+        self.v += np.cross(v1, 2 /(1 + (np.abs(t)**2).sum(-1)) * t)
 
         ## Adding second half of the magnetic impulse
         self.v += self.charge * E * dt / (2 * self.mass)

--- a/tokamak.py
+++ b/tokamak.py
@@ -66,7 +66,7 @@ x_line, y_line, z_line = tok.get_field_lines()
 Ec = 0.5 * mass * (vx**2 + vy**2 + vz**2)
 
 fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = fig.add_subplot(projection='3d')
 ax.plot(x, y, z)
 for i in range(16):
     ax.plot(x_line[i,:], y_line[i,:], z_line[i,:], 'r', linewidth=1)


### PR DESCRIPTION
I generally tell my students that ideally they do not just report bugs upstream, but also fix them, so this is my attempt at doing as I say...  The first commit updates the way a 3D plot is set up in matplotlib (I assume the previous method was deprecated; the code doesn't work as is with matplotlib 3.10). The second commit fixes the normalization issue I raised in #1 -- with it, energy conservation in the tokamak example is improved quite a bit.

EDIT: I added a third commit, which ensures that the first item in the results is the starting condition, as is assumed by the analytical estimates which the results are compared with. With that, one can take a 10 times larger time step and still have better accuracy.

Fixes #1